### PR TITLE
[RFR] Revisited the project structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,152 +4,35 @@
 
 If you are willing to contribute, open a pull request to complete, update or fill in a section. Thank you for doing so!
 
-## AngularJS
-
-[AngularJS](https://angularjs.org/) is a structural framework for dynamic web apps. It lets developers use HTML as their template language and lets them extend HTML’s syntax to express their application’s components clearly and succinctly.
-
-Angular’s data binding and dependency injection eliminate much of the code developers would otherwise have to write. And it all happens within the browser, making it an ideal partner with any server technology.
-
-## Babel
-
-[Babel](https://babeljs.io/) (formerly *6to5*) is essentially an [ECMAScript](#ecmascript-es) 6 and beyond transpiler. It means that it is a program that translates future’s JavaScript into today’s widely understood (by browsers) JavaScript. The idea behind such a tool is to allow developers to write their code using ECMAScript new features while still making it work in current browsers (and past) browsers.
-
-As of version 6, Babel also intends to be a platform, a suite of tools designed to create the next generation of JavaScript tooling. This means Babel is also supposed to power minifiers, linters, formatters, syntax highlighters, code completion tools, type checkers, codemod tools, and every other tool to be using the same foundation to do their job better than ever before.
-
-## Backbone
-
-[Backbone.js](http://backbonejs.org/) is a framework giving structure to web applications by providing models with key-value binding and custom events, collections with a rich API of enumerable functions, views with declarative event handling, and connects it all to existing APIs over a RESTful JSON interface.
-
-## Bower
-
-[Bower](http://bower.io/) is a package manager for front-end dependencies. It takes care of hunting, finding, downloading, saving these dependencies and keeping track of them in a manifest file called `bower.json`. Bower uses a flat dependency tree, requiring only one version for each package, reducing page load to a minimum.
-
-## Broccoli
-
-[Broccoli](https://github.com/broccolijs/broccoli) is a fast, reliable asset pipeline, supporting constant-time rebuilds and compact build definitions. Comparable to the [Rails](http://rubyonrails.org/) asset pipeline in scope, though it runs on [Node.js](#nodejs) and is backend-agnostic.
-
-## Browserify
-
-[Browserify](http://browserify.org/) is a tool that allows you to use the [require](https://nodejs.org/api/modules.html) [Node.js](#nodejs) function while working for the browser by bundling up all the required dependencies. 
-
-The idea behind Browserify is to make it possible to use existing libraries from [npm](#npm) even when writing code for the client side. To allow this, it goes through the code, request the required dependencies, then create a single file containing everything: both the dependencies and the code using them.
-
-## Brunch
-
-[Brunch](http://brunch.io/) is a builder. Not a generic task runner, but a specialized tool focusing on the production of a small number of deployment-ready files from a large number of heterogenous development files or trees.
-
-Brunch is fundamentally specialized and geared towards building assets, these files that get used in the end by the runtime platform, usually a web browser. It thus comes pre-equipped with a number of behaviors and features such as concatenation, minification and watching of source files.
-
-## CoffeeScript
-
-[CoffeeScript](http://coffeescript.org/) is a little language that compiles into JavaScript. It is an attempt to expose the good parts of JavaScript in a simple way and friendly syntax, the golden rule being: “It’s just JavaScript”.
-
-The code compiles one-to-one into the equivalent JS, and there is no interpretation at runtime. The compiled output is readable and pretty-printed, will work in every JavaScript runtime, and tends to run as fast or faster than the equivalent handwritten JavaScript.
-
-## D3.js
-
-[D3.js](http://d3js.org/) is a library for manipulating documents based on data. D3 helps bringing data to life using HTML, SVG, and CSS. Its emphasis on web standards gives the full capabilities of modern browsers without tying to a proprietary framework, combining powerful visualization components and a data-driven approach to DOM manipulation.
-
-## ECMAScript (ES)
-
-[ECMAScript](http://www.ecmascript.org/) (shortened as *ES*) is the standardized specification of the scripting language used by JavaScript, as well as less known languages JScript and ActionScript.
-
-The versioning convention of ECMAScript has been the subject of hot debates. We often refer to ES5 (understood by most browsers), ES6 (the future of JavaScript) and even ES7 (the far future of JavaScript), but the official appelation for ES6 would actually be ES2015. The intention is to publish a version of the specification a year, making the language evolve quicker than ever. Still, most developers use ES5 and ES6 terms.
-
-## Ember
-
-[Ember](http://emberjs.com/) section to be completed.
-
-## Express
-
-[Express](http://expressjs.com/en/index.html) is a fast, unopinionated, minimalist web framework for [Node.js](#nodejs). Express provides a thin layer of fundamental web application features, without obscuring Node.js features that developers already know and like. The myriad of HTTP utility methods and middleware provided by Express makes creating a robust API quick and easy.
-
-## Flux
-
-[Flux](https://facebook.github.io/flux/) is an application structure that is developed and used at Facebook to complement [React](#react)’s one-way data flow. With Flux, application state and logic are contained in stores.
-
-## Grunt
-
-[Grunt](http://gruntjs.com/) is a task runner aiming at automating tedious and possibly complex tasks. The idea behind Grunt (and its peer [Gulp](#gulp)) is to define tasks that perform (usually file-based) actions. These tasks can then be run through the command line or as part of another build step.
-
-## Gulp
-
-[Gulp](http://gulpjs.com/) is a task runner aiming at automating tedious and possibly complex tasks. The idea behind Gulp (and its peer [Grunt](#grunt)) is to define tasks that perform (usually file-based) actions. These tasks can then be run through the command line or as part of another build step. 
-
-Gulp also owes its success to its very large ecosystem of plugins, making it easy to perform everyday’s tasks without having to write much code.
-
-## jQuery
-
-[jQuery](https://jquery.com/) is a fast, small, and feature-rich JavaScript library. It makes things like HTML document traversal and manipulation, event handling, animation, and Ajax much simpler with an easy-to-use API that works across a multitude of browsers. With a combination of versatility and extensibility, jQuery has changed the way that millions of people write JavaScript.
-
-## Knockout
-
-[Knockout](http://knockoutjs.com/) (shortened as *KO*) is a JavaScript library that helps developers creating rich, responsive display and editor user interfaces with a clean underlying data model. Knockout helps implementing sections of UI that update dynamically (e.g. changes depending on user’s actions or when external data source gets updated) more simply and maintainably.
-
-## Meteor
-
-[Meteor](https://www.meteor.com/) section to be completed.
-
-## MooTools
-
-[MooTools](http://mootools.net/) section to be completed.
-
-## Node.js
-
-[Node.js](https://nodejs.org/en/) is an open-source, cross-platform runtime environment for developing server-side web applications built on Chrome’s [V8](#v8) JavaScript engine. These applications are written in JavaScript and can be run within the Node.js runtime.
-
-Node.js uses an event-driven, non-blocking I/O (input/output) model that makes it lightweight and efficient as well as optimized for real-time web applications’ throughput and scalability.
-
-Its work is hosted and supported by the [Node.js Foundation](https://nodejs.org/en/foundation/), a collaborative project at Linux Foundation.
-
-## npm
-
-[npm](https://www.npmjs.com/) is utility to help publishing packages to, and installing from, an npm repository. The repository npmjs.com is the best known, and contains many useful community written and tested packages.
-
-## nvm
-
-[nvm](https://github.com/creationix/nvm/blob/master/README.markdown) is a utility to help run multiple versions of [Node.js](#nodejs) (and its branches) on the same machine. It can install, list, and choose versions. It is analagous to [RVM](https://rvm.io/) (Ruby Version Manager).
-
-## PhoneGap
-
-[PhoneGap](http://phonegap.com/) section to be completed.
-
-## React
-
-[React](https://facebook.github.io/react/) is a library developed and used at Facebook for building user interfaces. It can be seen as the V in MVC (Model View Controller) as it makes no assumptions about the rest of the technology stack. Using [React Native](#react-native) it can even be used to power native apps.
-
-In React you can write HTML directly in JS using an XML-like syntax called JSX. JSX compiles to JS and is optional, but does make the code more expressive.
-
-Data flow in React is one-way which makes it easier to reason about and avoid mistakes. This quality can be enhanced using [Flux](#flux), Facebook’s complementary application architecture, or [Redux](#redux) which many people see as a “better Flux”.
-
-## React Native
-
-[React Native](https://facebook.github.io/react-native/) section to be completed.
-
-## Redux
-
-[Redux](http://redux.js.org/) is a predictable state container for JavaScript apps, which is a fancy way of saying it controls application state and state mutations. It does so by keeping state in a store, which is the single source of truth.
-
-Redux is an alternative to [Flux](#flux) and used a lot together with [React](#react), but you can use it with any other view library.
-
-## RequireJS
-
-[RequireJS](http://requirejs.org/) section to be completed.
-
-## TypeScript
-
-[TypeScript](http://www.typescriptlang.org/) is a super-set of the JavaScript language that introduces types (plus interfaces and new JavaScript features). It allows type-checking during development time with supported editors such as [Visual Studio](https://code.visualstudio.com/). The compiler requires information about the “shape” of a module in a _type-definition-file_.
-
-## Yeoman
-
-[Yeoman](http://yeoman.io/) is both a generator builder and an ecosystem. A generator is basically a plugin which will generate files based on user input. Plugins can be run with the `yo` command to scaffold complete projects or useful parts.
-
-Therefore, the goal of a Yeoman generator is usually (but not necessarily) to speed up the setup and installation process of a project or part of a project by packaging it inside a module that can be configured through a question/reply workflow from the command line.
-
-## V8
-
-[V8](https://code.google.com/p/v8/) section to be completed.
-
-## Webpack
-
-[Webpack](https://github.com/webpack/webpack) helps you managing dependencies in your project, and also offers a friendly and fast development environment, simplifying a lot of common tasks behind a simple configuration file. It also allows you to bundle your modules into static assets for browsers. Its killer feature is the known as [hot module replacement](https://github.com/webpack/docs/wiki/hot-module-replacement-with-webpack), which lets your live code in the browser update automatically as you change files in your preferred editor without a page reload. 
+## Glossary
+
+* [AngularJS](/glossary/ANGULARJS.md): a structural framework for dynamic web apps.
+* [Babel](/glossary/BABEL.md): an ECMAScript 6 (and beyond) to ECMAScript 5 code translator (transpiler).
+* [Backbone](/glossary/BACKBONE.md): a structural framework for dynamic web apps.
+* [Bower](/glossary/BOWER.md): a package manager for front-end dependencies.
+* [Broccoli](/glossary/BROCCOLI.md): a fast and reliable asset pipeline.
+* [Browserify](/glossary/BROWSERIFY.md): a tool making possible to use the `require` function from Node.js while working for the browser.
+* [Brunch](/glossary/BRUNCH.md): a tool focusing on the production of deployment-ready files from development files.
+* [CoffeeScript](/glossary/COFFEESCRIPT.md): a language that compiles into JavaScript.
+* [D3.js](/glossary/D3JS.md): a library for manipulating documents based on data.
+* [ECMAScript](/glossary/ECMASCRIPT.md): the standardized specification of the scripting language used by JavaScript.
+* [Ember](/glossary/EMBER.md): to be completed.
+* [Express](/glossary/EXPRESS.md): a fast, unopinionated, minimalist web framework for Node.js.
+* [Flux](/glossary/FLUX.md): an application structure focusing on improved data flow.
+* [Grunt](/glossary/GRUNT.md): a task runner aiming at automating tedious and possibly complex tasks.
+* [Gulp](/glossary/GULP.md): a task runner aiming at automating tedious and possibly complex tasks.
+* [jQuery](/glossary/JQUERY.md): a fast, small, and feature-rich client-side library.
+* [Knockout](/glossary/KNOCKOUT.md): a library that helps developers creating user interfaces with a clean underlying data model.
+* [Meteor](/glossary/METEOR.md): to be completed.
+* [Mootools](/glossary/MOOTOOLS.md): to be completed.
+* [Node.js](/glossary/NODEJS.md): a cross-platform runtime environment for developing server-side applications built on V8 engine.
+* [npm](/glossary/NPM.md): a utility to help publishing packages to, and installing from, an npm repository.
+* [nvm](/glossary/NVM.md): a utility to help run multiple versions of Node.js on the same machine.
+* [PhoneGap](/glossary/PHONEGAP.md): to be completed.
+* [React](/glossary/REACT.md): a library developed and used at Facebook for building user interfaces.
+* [Redux](/glossary/REDUX.md): a predictable state container for apps.
+* [Require.js](/glossary/REQUIREJS.md): to be completed.
+* [TypeScript](/glossary/TYPESCRIPT.md): a super-set of the JavaScript language that introduces types.
+* [V8](/glossary/V8.md): to be completed.
+* [webpack](/glossary/WEBPACK.md): a dependency manager with a friendly and fast development environment, simplifying a lot of common tasks.
+* [Yeoman](/glossary/YEOMAN.md): a generator builder to speed up the setup and installation process of a project or part of a project.

--- a/glossary/ANGULARJS.md
+++ b/glossary/ANGULARJS.md
@@ -1,0 +1,5 @@
+# AngularJS
+
+[AngularJS](https://angularjs.org/) is a structural framework for dynamic web apps. It lets developers use HTML as their template language and lets them extend HTML’s syntax to express their application’s components clearly and succinctly.
+
+Angular’s data binding and dependency injection eliminate much of the code developers would otherwise have to write. And it all happens within the browser, making it an ideal partner with any server technology.

--- a/glossary/BABEL.md
+++ b/glossary/BABEL.md
@@ -1,0 +1,5 @@
+# Babel
+
+[Babel](https://babeljs.io/) (formerly *6to5*) is essentially an [ECMAScript](ECMASCRIPT.md) 6 and beyond transpiler. It means that it is a program that translates future’s JavaScript into today’s widely understood (by browsers) JavaScript. The idea behind such a tool is to allow developers to write their code using ECMAScript new features while still making it work in current browsers (and past) browsers.
+
+As of version 6, Babel also intends to be a platform, a suite of tools designed to create the next generation of JavaScript tooling. This means Babel is also supposed to power minifiers, linters, formatters, syntax highlighters, code completion tools, type checkers, codemod tools, and every other tool to be using the same foundation to do their job better than ever before.

--- a/glossary/BACKBONE.md
+++ b/glossary/BACKBONE.md
@@ -1,0 +1,3 @@
+# Backbone
+
+[Backbone.js](http://backbonejs.org/) is a framework giving structure to web applications by providing models with key-value binding and custom events, collections with a rich API of enumerable functions, views with declarative event handling, and connects it all to existing APIs over a RESTful JSON interface.

--- a/glossary/BOWER.md
+++ b/glossary/BOWER.md
@@ -1,0 +1,3 @@
+# Bower
+
+[Bower](http://bower.io/) is a package manager for front-end dependencies. It takes care of hunting, finding, downloading, saving these dependencies and keeping track of them in a manifest file called `bower.json`. Bower uses a flat dependency tree, requiring only one version for each package, reducing page load to a minimum.

--- a/glossary/BROCCOLI.md
+++ b/glossary/BROCCOLI.md
@@ -1,0 +1,3 @@
+# Broccoli
+
+[Broccoli](https://github.com/broccolijs/broccoli) is a fast, reliable asset pipeline, supporting constant-time rebuilds and compact build definitions. Comparable to the [Rails](http://rubyonrails.org/) asset pipeline in scope, though it runs on [Node.js](NODEJS.md) and is backend-agnostic.

--- a/glossary/BROWSERIFY.md
+++ b/glossary/BROWSERIFY.md
@@ -1,0 +1,5 @@
+# Browserify
+
+[Browserify](http://browserify.org/) is a tool that allows you to use the [require](https://nodejs.org/api/modules.html) [Node.js](NODEJS.md) function while working for the browser by bundling up all the required dependencies. 
+
+The idea behind Browserify is to make it possible to use existing libraries from [npm](NPM.md) even when writing code for the client side. To allow this, it goes through the code, request the required dependencies, then create a single file containing everything: both the dependencies and the code using them.

--- a/glossary/BRUNCH.md
+++ b/glossary/BRUNCH.md
@@ -1,0 +1,5 @@
+# Brunch
+
+[Brunch](http://brunch.io/) is a builder. Not a generic task runner, but a specialized tool focusing on the production of a small number of deployment-ready files from a large number of heterogenous development files or trees.
+
+Brunch is fundamentally specialized and geared towards building assets, these files that get used in the end by the runtime platform, usually a web browser. It thus comes pre-equipped with a number of behaviors and features such as concatenation, minification and watching of source files.

--- a/glossary/COFFEESCRIPT.md
+++ b/glossary/COFFEESCRIPT.md
@@ -1,0 +1,5 @@
+# CoffeeScript
+
+[CoffeeScript](http://coffeescript.org/) is a little language that compiles into JavaScript. It is an attempt to expose the good parts of JavaScript in a simple way and friendly syntax, the golden rule being: “It’s just JavaScript”.
+
+The code compiles one-to-one into the equivalent JS, and there is no interpretation at runtime. The compiled output is readable and pretty-printed, will work in every JavaScript runtime, and tends to run as fast or faster than the equivalent handwritten JavaScript.

--- a/glossary/D3JS.md
+++ b/glossary/D3JS.md
@@ -1,0 +1,3 @@
+# D3.js
+
+[D3.js](http://d3js.org/) is a library for manipulating documents based on data. D3 helps bringing data to life using HTML, SVG, and CSS. Its emphasis on web standards gives the full capabilities of modern browsers without tying to a proprietary framework, combining powerful visualization components and a data-driven approach to DOM manipulation.

--- a/glossary/ECMASCRIPT.md
+++ b/glossary/ECMASCRIPT.md
@@ -1,0 +1,5 @@
+# ECMAScript (ES)
+
+[ECMAScript](http://www.ecmascript.org/) (shortened as *ES*) is the standardized specification of the scripting language used by JavaScript, as well as less known languages JScript and ActionScript.
+
+The versioning convention of ECMAScript has been the subject of hot debates. We often refer to ES5 (understood by most browsers), ES6 (the future of JavaScript) and even ES7 (the far future of JavaScript), but the official appelation for ES6 would actually be ES2015. The intention is to publish a version of the specification a year, making the language evolve quicker than ever. Still, most developers use ES5 and ES6 terms.

--- a/glossary/EMBER.md
+++ b/glossary/EMBER.md
@@ -1,0 +1,3 @@
+# Ember
+
+[Ember](http://emberjs.com/) section to be completed.

--- a/glossary/EXPRESS.md
+++ b/glossary/EXPRESS.md
@@ -1,0 +1,3 @@
+# Express
+
+[Express](http://expressjs.com/en/index.html) is a fast, unopinionated, minimalist web framework for [Node.js](NODEJS.md). Express provides a thin layer of fundamental web application features, without obscuring Node.js features that developers already know and like. The myriad of HTTP utility methods and middleware provided by Express makes creating a robust API quick and easy.

--- a/glossary/FLUX.md
+++ b/glossary/FLUX.md
@@ -1,0 +1,3 @@
+# Flux
+
+[Flux](https://facebook.github.io/flux/) is an application structure that is developed and used at Facebook to complement [React](REACT.md)’s one-way data flow. With [Flux](/FLUX.md), application state and logic are contained in stores.

--- a/glossary/GRUNT.md
+++ b/glossary/GRUNT.md
@@ -1,0 +1,3 @@
+# Grunt
+
+[Grunt](http://gruntjs.com/) is a task runner aiming at automating tedious and possibly complex tasks. The idea behind Grunt (and its peer [Gulp](GULP.md)) is to define tasks that perform (usually file-based) actions. These tasks can then be run through the command line or as part of another build step.

--- a/glossary/GULP.md
+++ b/glossary/GULP.md
@@ -1,0 +1,5 @@
+# Gulp
+
+[Gulp](http://gulpjs.com/) is a task runner aiming at automating tedious and possibly complex tasks. The idea behind Gulp (and its peer [Grunt](GRUNT.md)) is to define tasks that perform (usually file-based) actions. These tasks can then be run through the command line or as part of another build step. 
+
+Gulp also owes its success to its very large ecosystem of plugins, making it easy to perform everyday’s tasks without having to write much code.

--- a/glossary/JQUERY.md
+++ b/glossary/JQUERY.md
@@ -1,0 +1,3 @@
+# jQuery
+
+[jQuery](https://jquery.com/) is a fast, small, and feature-rich JavaScript library. It makes things like HTML document traversal and manipulation, event handling, animation, and Ajax much simpler with an easy-to-use API that works across a multitude of browsers. With a combination of versatility and extensibility, jQuery has changed the way that millions of people write JavaScript.

--- a/glossary/KNOCKOUT.md
+++ b/glossary/KNOCKOUT.md
@@ -1,0 +1,3 @@
+# Knockout
+
+[Knockout](http://knockoutjs.com/) (shortened as *KO*) is a JavaScript library that helps developers creating rich, responsive display and editor user interfaces with a clean underlying data model. Knockout helps implementing sections of UI that update dynamically (e.g. changes depending on user’s actions or when external data source gets updated) more simply and maintainably.

--- a/glossary/METEOR.md
+++ b/glossary/METEOR.md
@@ -1,0 +1,3 @@
+# Meteor
+
+[Meteor](https://www.meteor.com/) section to be completed.

--- a/glossary/MOOTOOLS.md
+++ b/glossary/MOOTOOLS.md
@@ -1,0 +1,3 @@
+# MooTools
+
+[MooTools](http://mootools.net/) section to be completed.

--- a/glossary/NODEJS.md
+++ b/glossary/NODEJS.md
@@ -1,0 +1,7 @@
+# Node.js
+
+[Node.js](https://nodejs.org/en/) is an open-source, cross-platform runtime environment for developing server-side web applications built on Chrome’s [V8](#v8) JavaScript engine. These applications are written in JavaScript and can be run within the Node.js runtime.
+
+Node.js uses an event-driven, non-blocking I/O (input/output) model that makes it lightweight and efficient as well as optimized for real-time web applications’ throughput and scalability.
+
+Its work is hosted and supported by the [Node.js Foundation](https://nodejs.org/en/foundation/), a collaborative project at Linux Foundation.

--- a/glossary/NPM.md
+++ b/glossary/NPM.md
@@ -1,0 +1,3 @@
+# npm
+
+[npm](https://www.npmjs.com/) is a utility to help publishing packages to, and installing from, an npm repository. The repository npmjs.com is the best known, and contains many useful community written and tested packages.

--- a/glossary/NVM.md
+++ b/glossary/NVM.md
@@ -1,0 +1,3 @@
+# nvm
+
+[nvm](https://github.com/creationix/nvm/blob/master/README.markdown) is a utility to help run multiple versions of [Node.js](NODEJS.md) (and its branches) on the same machine. It can install, list, and choose versions. It is analagous to [RVM](https://rvm.io/) (Ruby Version Manager).

--- a/glossary/PHONEGAP.md
+++ b/glossary/PHONEGAP.md
@@ -1,0 +1,3 @@
+# PhoneGap
+
+[PhoneGap](http://phonegap.com/) section to be completed.

--- a/glossary/REACT.md
+++ b/glossary/REACT.md
@@ -1,0 +1,11 @@
+# React
+
+[React](https://facebook.github.io/react/) is a library developed and used at Facebook for building user interfaces. It can be seen as the V in MVC (Model View Controller) as it makes no assumptions about the rest of the technology stack. Using [React Native](#react-native) it can even be used to power native apps.
+
+In React you can write HTML directly in JS using an XML-like syntax called JSX. JSX compiles to JS and is optional, but does make the code more expressive.
+
+Data flow in React is one-way which makes it easier to reason about and avoid mistakes. This quality can be enhanced using [Flux](FLUX.md), Facebook’s complementary application architecture, or [Redux](REDUX.md) which many people see as a “better Flux”.
+
+# React Native
+
+[React Native](https://facebook.github.io/react-native/) section to be completed.

--- a/glossary/REDUX.md
+++ b/glossary/REDUX.md
@@ -1,0 +1,5 @@
+# Redux
+
+[Redux](http://redux.js.org/) is a predictable state container for JavaScript apps, which is a fancy way of saying it controls application state and state mutations. It does so by keeping state in a store, which is the single source of truth.
+
+Redux is an alternative to [Flux](FLUX.md) and used a lot together with [React](REACT.md), but you can use it with any other view library.

--- a/glossary/REQUIREJS.md
+++ b/glossary/REQUIREJS.md
@@ -1,0 +1,3 @@
+# RequireJS
+
+[RequireJS](http://requirejs.org/) section to be completed.

--- a/glossary/TYPESCRIPT.md
+++ b/glossary/TYPESCRIPT.md
@@ -1,0 +1,3 @@
+# TypeScript
+
+[TypeScript](http://www.typescriptlang.org/) is a super-set of the JavaScript language that introduces types (plus interfaces and new JavaScript features). It allows type-checking during development time with supported editors such as [Visual Studio](https://code.visualstudio.com/). The compiler requires information about the “shape” of a module in a _type-definition-file_.

--- a/glossary/V8.md
+++ b/glossary/V8.md
@@ -1,0 +1,3 @@
+# V8
+
+[V8](https://code.google.com/p/v8/) section to be completed.

--- a/glossary/WEBPACK.md
+++ b/glossary/WEBPACK.md
@@ -1,0 +1,3 @@
+# Webpack
+
+[Webpack](https://github.com/webpack/webpack) helps you managing dependencies in your project, and also offers a friendly and fast development environment, simplifying a lot of common tasks behind a simple configuration file. It also allows you to bundle your modules into static assets for browsers. Its killer feature is the known as [hot module replacement](https://github.com/webpack/docs/wiki/hot-module-replacement-with-webpack), which lets your live code in the browser update automatically as you change files in your preferred editor without a page reload. 

--- a/glossary/YEOMAN.md
+++ b/glossary/YEOMAN.md
@@ -1,0 +1,5 @@
+# Yeoman
+
+[Yeoman](http://yeoman.io/) is both a generator builder and an ecosystem. A generator is basically a plugin which will generate files based on user input. Plugins can be run with the `yo` command to scaffold complete projects or useful parts.
+
+Therefore, the goal of a Yeoman generator is usually (but not necessarily) to speed up the setup and installation process of a project or part of a project by packaging it inside a module that can be configured through a question/reply workflow from the command line.


### PR DESCRIPTION
This pull-request revisits the project structure to have one entry per file rather than everything in the README. The latter becomes a table of contents. 

It might looks overkill, but I truly think that the README will soon become unpractical and very crowded as we keeping adding more.

Also, having one entry per file leaves some extra room for small projects that we would not have listed in the README otherwise.

Last but not least, it allows us to write more on each entry, without risking of crowding everything.

Any opinion?
