### PR TITLE
[RFR] Improved “Babel” entry

### DIFF
--- a/glossary/BABEL.md
+++ b/glossary/BABEL.md
@@ -1,5 +1,5 @@
 # Babel
 
-[Babel](https://babeljs.io/) (formerly *6to5*) is essentially an [ECMAScript](ECMASCRIPT.md) 6 and beyond transpiler. It means that it is a program that translates future’s JavaScript into today’s widely understood (by browsers) JavaScript. The idea behind such a tool is to allow developers to write their code using ECMAScript new features while still making it work in current browsers (and past) browsers.
+[Babel](https://babeljs.io/) (formerly *6to5*) is essentially an [ECMAScript](ECMASCRIPT.md) 2015 (ES6) and beyond transpiler. It means that it is a program that translates future’s JavaScript into today’s widely understood (by browsers) JavaScript. The idea behind such a tool is to allow developers to write their code using ECMAScript's new features while still making it work in current environments (and past) environments.
 
 As of version 6, Babel also intends to be a platform, a suite of tools designed to create the next generation of JavaScript tooling. This means Babel is also supposed to power minifiers, linters, formatters, syntax highlighters, code completion tools, type checkers, codemod tools, and every other tool to be using the same foundation to do their job better than ever before.


### PR DESCRIPTION
Change ES6 into ES2015, fix typo, change 'browsers' to environments as Babel can run in other JS environments such as Node.
