### PR TITLE
docs: Fix simple typo, ther -> there

### DIFF
--- a/_glossary/LOCALFORAGE.md
+++ b/_glossary/LOCALFORAGE.md
@@ -170,7 +170,7 @@ If you’re using localForage in your own build system (e.g. browserify or webpa
 
 ### Framework Support
 
-If you use a framework listed, ther’s a localForage storage driver for the models in your framework so you can store data offline with localForage. We have drivers for the following frameworks:
+If you use a framework listed, there’s a localForage storage driver for the models in your framework so you can store data offline with localForage. We have drivers for the following frameworks:
 
 - [AngularJS](https://github.com/ocombe/angular-localForage)
 - [Backbone](https://github.com/mozilla/localForage-backbone)


### PR DESCRIPTION
There is a small typo in _glossary/LOCALFORAGE.md.

Should read `there` rather than `ther`.

